### PR TITLE
Suppress maximizing on win32 UI  ==>  master

### DIFF
--- a/ui/win32/win32ui.c
+++ b/ui/win32/win32ui.c
@@ -182,6 +182,10 @@ fuse_window_proc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
       if( paused ) menu_machine_pause( 0 );
       return 0;
 
+    case WM_NCLBUTTONDBLCLK:
+      /* Don't allow double click on title bar, suppressing window maximizing */
+      return 0;
+
     case WM_ENTERMENULOOP:
     case WM_ENTERSIZEMOVE:
     {


### PR DESCRIPTION
Suppressing doubleclick message on title bar to not do window maximizing (fixes bug #488).