### PR TITLE
fix:  Reverting recent change in configure.ac, was failing in WII cross-compile build.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,15 +87,7 @@ dnl Check for big endianness
 AC_C_BIGENDIAN
 
 dnl Checks for header files.
-m4_warn([obsolete],
-[The preprocessor macro `STDC_HEADERS' is obsolete.
-  Except in unusual embedded environments, you can safely include all
-  ISO C90 headers unconditionally.])dnl
-# Autoupdate added the next two lines to ensure that your configure
-# script's behavior did not change.  They are probably safe to remove.
-AC_CHECK_INCLUDES_DEFAULT
-AC_PROG_EGREP
-
+AC_HEADER_STDC
 AC_CHECK_HEADERS(
   libgen.h \
   siginfo.h \


### PR DESCRIPTION

Breaking commit: d36545de5631823a86a4e9968698491ea2caf3f5

configure.ac:96: error: possibly undefined macro: AC_CHECK_INCLUDES_DEFAULT
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1 Error: Process completed with exit code 1.

https://sourceforge.net/p/arki55-fuse-mod/tickets/11/