### PR TITLE
ci: Daily test (pre)release as new release with date+time, dropping older releases (#42)

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: "Merge fresh ${{ vars.PARENT_FUSE_BRANCH }} from ${{ vars.PARENT_FUSE_REPO }}"
@@ -29,6 +29,7 @@ jobs:
           git push
 
   # Build and release nightly prerelease version from master (no draft)
+  # Add current date and time to the tag, keep latest 5
   master:
     needs: [catchup]
     name: "Nightly build from master"
@@ -38,5 +39,7 @@ jobs:
       draft: false
       generateReleaseNotes: true
       libspectrum_branch: "master"
+      add_date_time: true
+      keep_latest: 5
     secrets:
       RELEASE_TOKEN: "${{ secrets.RELEASE_TOKEN }}"

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -25,7 +25,17 @@ on:
         required: true
         default: "master"
         description: "Libspectrum's branch to use"
-    
+      add_date_time:
+        type: boolean
+        required: false
+        default: false
+        description: "If enabled, current date and time is added to the name and tag of release, making it unique." 
+      keep_latest:
+        type: number
+        required: false
+        default: 0
+        description: "Number of latest releases to keep (only if date and time is appended)"
+
   # Reused also from nightly build workflow
   workflow_call:
     inputs:
@@ -48,6 +58,16 @@ on:
         required: false
         default: "master"
         description: "Libspectrum's branch to use"
+      add_date_time:
+        type: boolean
+        required: false
+        default: false
+        description: "If enabled, current date and time is added to the name and tag of release, making it unique." 
+      keep_latest:
+        type: number
+        required: false
+        default: 0
+        description: "Number of latest releases to keep (only if date and time is appended)"
     secrets:
       RELEASE_TOKEN:
           required: true
@@ -108,6 +128,9 @@ jobs:
       - build-win32-ui-default
       - build-sdl-ui-sdl-sound
     runs-on: ubuntu-latest
+    outputs:
+      use_tag: ${{ steps.prep.outputs.use_tag }}
+      use_tag_base: ${{ steps.prep.outputs.use_tag_base }}
     steps:
       # Prepare friendly tag name ( slashes => _ )
       - name: (1) Prepare variables
@@ -115,16 +138,43 @@ jobs:
         run: |
           ref_name="${{ github.ref_name }}"
           use_tag="test_${ref_name//\//_}"
-          echo "Tag name: ${use_tag}"
-          echo "use_tag=${use_tag}" >> "$GITHUB_OUTPUT"
+          use_tag_base="${use_tag}"
 
-      - name: (2) Download all generated files
+          if [[ ${{ inputs.add_date_time == 'true' }} ]]; then
+            dt=`date "+%Y-%m-%d--%H-%M-%S"`
+            use_tag="${use_tag}_${dt}"
+          fi
+
+          echo "Tag name: ${use_tag}"
+          echo "Tag base: ${use_tag_base}"
+          echo "use_tag=${use_tag}" >> "$GITHUB_OUTPUT"
+          echo "use_tag_base=${use_tag_base}" >> "$GITHUB_OUTPUT"
+
+      # Prepare readme file for created release
+      - name: (2) Prepare description file
+        id: readme
+        run: |
+          readme_file="README.md"
+          echo "README file: ${readme_file}"
+          echo "readme_file=${readme_file}" >> "$GITHUB_OUTPUT"
+          
+          # Generate readme file.
+          # Make sure to be always unique, otherwise sync to SourceForge will not work.
+          # Adding current date and time should suffice.
+          echo -e "### ${{ inputs.reason }}\n\nRepo: ${{ github.repositoryUrl }}\n\nBranch: ${{ github.ref_name }}\n\nActor: ${{ github.actor }}\n\nCreated: `date -u`\n\n\
+          " >> "$readme_file"
+          echo "Content: "
+          cat "$readme_file"
+
+      - name: (3) Download all generated files
         uses: actions/download-artifact@v3
 
-      - name: (3) Created release with zip files
+      - name: (4) Create release with zip files
         uses: ncipollo/release-action@v1
+        id: create-release
         with:
           name: "Test build for ${{ github.ref_name }}"
+
           # Attach all generated build zips
           artifacts: "*/*.zip"
           # determines structure of files in Source Forge
@@ -139,7 +189,61 @@ jobs:
           token: "${{ secrets.RELEASE_TOKEN }}"
           # Allow updating releases
           allowUpdates: true
+          # Force updating of artifacts
+          replacesArtifacts: true
+          removeArtifacts: true
           # Generate release note?
           generateReleaseNotes: ${{ inputs.generateReleaseNotes }}
           # Any error should fail the build
           artifactErrorsFailBuild: true
+          # Do not set body now - only in the next step
+
+      # Allow GitHub take breath, sync stuff
+      - run: sleep 5
+
+      - name: (5) Update body of release (forcing files sync to SourceForge)
+        uses: ncipollo/release-action@v1
+        with:
+          # Repeat some values as they were in the previous step
+          name: "Test build for ${{ github.ref_name }}"
+          tag: "${{ steps.prep.outputs.use_tag }}"
+          prerelease: true
+          draft: ${{ inputs.draft }}
+          commit: ${{ github.ref_name }}
+          token: "${{ secrets.RELEASE_TOKEN }}"
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          generateReleaseNotes: ${{ inputs.generateReleaseNotes }}
+
+          # Keep files as they are here - no adding, updating or deleting
+
+          # Use readme.md file for the body part NOW
+          bodyFile: ${{ steps.readme.outputs.readme_file }}
+
+      - name: (6) Adding summary
+        run: |
+          echo '### New test release has been created :open_file_folder:' >> $GITHUB_STEP_SUMMARY
+          echo 'Id: ${{ steps.create-release.outputs.id }}' >> $GITHUB_STEP_SUMMARY
+          echo 'Url: ${{ steps.create-release.outputs.html_url }}' >> $GITHUB_STEP_SUMMARY
+          echo 'Upload Url: ${{ steps.create-release.outputs.upload_url }}' >> $GITHUB_STEP_SUMMARY
+          echo 'Tag base: ${{ steps.prep.outputs.use_tag_base }}' >> $GITHUB_STEP_SUMMARY
+          echo 'Tag name: ${{ steps.prep.outputs.use_tag }}' >> $GITHUB_STEP_SUMMARY
+
+  ###############################################
+  ### Cleanup, delete olf releases (optional) ###
+  ###############################################
+  cleanup:
+    if: inputs.add_date_time && inputs.keep_latest>0
+    name: "Delete Older Releases"
+    needs:
+     - release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Older Releases
+        uses: dev-drprasad/delete-older-releases@v0.2.1
+        with:
+          keep_latest: ${{ inputs.keep_latest }}
+          delete_tags: true
+          delete_tag_pattern: "${{ needs.release.outputs.use_tag_base }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}"


### PR DESCRIPTION

plus:
- repeat release creation/update to update body after files have been updated. Forcing updating of files in SourceForge, if release existed already.
- Append current date and time to nightly build's tag, remove all but the last 5 such releases.

https://github.com/arki55/fuse-fuse/pull/42
https://sourceforge.net/p/arki55-fuse-mod/tickets/13/