### PR TITLE
ci: Fix date of last commit when packing release ==>  arki55/master

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -216,7 +216,7 @@ jobs:
           echo "GIT ref name: ${git_ref_name}"
           echo "git_ref_name=${git_ref_name}" >> "$GITHUB_OUTPUT"
 
-          git_log_date_iso=$(git log --date=iso -1 | grep -Po "20[0-9][0-9]-[01][0-9]-[0123][0-9]")
+          git_log_date_iso=$(git log --date=iso -1 --no-merges | grep -Po "20[0-9][0-9]-[01][0-9]-[0123][0-9]")
           echo "GIT log date ISO: ${git_log_date_iso}"
           echo "git_log_date_iso=${git_log_date_iso}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -198,12 +198,15 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # Prepare variables
       - name: "Prepare variables"
         id: prep-vars
         run: |
           cd ${GITHUB_WORKSPACE}
+          git fetch --prune
           
           current_date_time=`date "+%Y-%m-%d--%H-%M-%S"`
           echo "Current date time: ${current_date_time}"


### PR DESCRIPTION
Before determining date of last commit, checkout and fetch the latest version of branch. Do not checkout on hash of the event.